### PR TITLE
Run tests during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ EXPOSE 5000
 COPY . /src
 WORKDIR /src
 RUN bundle
+RUN bundle exec rspec
 
 CMD ["/usr/local/bundle/bin/puma", "-t", "2:16", "-p", "5000"]

--- a/test-image
+++ b/test-image
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-IMAGE_NAME="$1"
-
-docker run -i --rm $IMAGE_NAME rspec


### PR DESCRIPTION
Run tests during docker build since test-image hook inexplicably breaks the generic build script